### PR TITLE
Use a relative directory for the PostgreSQL data directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - satchel_data:/var/lib/postgresql/data
+      - ./satchel_data:/var/lib/postgresql/data
       - ./satchel/init.sql:/docker-entrypoint-initdb.d/init.sql
   postroom:
     build:


### PR DESCRIPTION
This seemed to be the default behaviour on Windows but
worked differently using Linux.